### PR TITLE
Fix #7, add setIdentifier() to the Phenotype in BethlemMyopathyExample, others

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hapi-pheno-client
 FHIR Client for working with phenopackets.
 
-## Running this package
+## Running this package: mvn spring-boot:run
 The demo app is intended to be run together with a HAPI FHIR server that
 has ingested the GA4GH [Phenopacket IG](http://phenopackets.org/core-ig/index.html).
 This [repository](https://github.com/pnrobinson/hapi-pheno-server) contains a copy of the 
@@ -9,3 +9,6 @@ HAPI FHIR JPA starter project that has been modified to ingest the Phenopacket I
 By default it will start a server on localhost:8888, which is the location that this
 client application will target by default.
 
+The location of the core-ig needs to be added to the application.properties file, 
+and for now, the jar rebuilt.
+./src/main/resources/application.properties

--- a/src/main/java/org/monarchinitiative/hapiphenoclient/PhenoClientConsoleApplication.java
+++ b/src/main/java/org/monarchinitiative/hapiphenoclient/PhenoClientConsoleApplication.java
@@ -45,7 +45,7 @@ public class PhenoClientConsoleApplication implements CommandLineRunner {
         Bundle patientBundle = demoRunner.searchForPhenopacketById(bethlem.getPhenopacketId());
         System.out.println(patientBundle);
         System.out.println("*************************");
-        Individual individual = demoRunner.extractIndividual(bethlem.getUnqualifiedIndidualId());
+        Individual individual = demoRunner.extractIndividual(bethlem.getUnqualifiedIndividualId());
         List<PhenotypicFeature> features = demoRunner.retrievePhenotypicFeaturesFromBundle(patientBundle);
         List<Measurement> measurements = demoRunner.retrieveMeasurementsFromBundle(patientBundle);
         Phenopacket ga4ghPhenopacket = Ga4GhPhenopacket.fromFhir(individual, features, measurements);

--- a/src/main/java/org/monarchinitiative/hapiphenoclient/examples/BethlemMyopathyExample.java
+++ b/src/main/java/org/monarchinitiative/hapiphenoclient/examples/BethlemMyopathyExample.java
@@ -37,7 +37,7 @@ public class BethlemMyopathyExample implements PhenoExample {
      * This method would then return "208"
      * @return the individual id (assigned by FHIR server) as string
      */
-    public String getUnqualifiedIndidualId() {
+    public String getUnqualifiedIndividualId() {
         return individual.getIdElement().toUnqualified().getIdPart();
     }
 
@@ -62,9 +62,10 @@ public class BethlemMyopathyExample implements PhenoExample {
     @Override
     public Phenopacket phenopacket() {
         this.phenopacket = new Phenopacket();
+        this.phenopacket.setIdentifier(new Identifier().setValue(phenopacketIdentifier));
         this.phenopacket.setIndividual(individual);
         this.phenopacket.setStatus(Composition.CompositionStatus.FINAL);
-        this.phenopacket.setSubject(new Reference("Patient/" + getUnqualifiedIndidualId()));
+        this.phenopacket.setSubject(new Reference("Patient/" + getUnqualifiedIndividualId()));
         CodeableConcept ga4ghType = new CodeableConcept();
         ga4ghType.addCoding(
                 new Coding().setSystem(GA4GH_SYSTEM)
@@ -73,18 +74,18 @@ public class BethlemMyopathyExample implements PhenoExample {
         this.phenopacket.setDate(new Date()); // current date/time
         this.phenopacket.addAuthor().setReference(williamHarvey.getReference()).setDisplay(williamHarvey.getDisplayName());
         this.phenopacket.setTitle("Phenopacket: Bethlem Myopathy");
-        phenopacket.setId("example.id");
+        this.phenopacket.setId("example.id");
         return phenopacket;
     }
 
 
     public List<PhenotypicFeature> phenotypicFeatureList() {
         List<PhenotypicFeature> features = new ArrayList<>();
-        PhenotypicFeature pf = PhenotypicFeature.createObservation("HP:0001558", "Decreased fetal movement", getUnqualifiedIndidualId());
+        PhenotypicFeature pf = PhenotypicFeature.createObservation("HP:0001558", "Decreased fetal movement", getUnqualifiedIndividualId());
         features.add(pf);
-        PhenotypicFeature pf2 = PhenotypicFeature.createObservation("HP:0011463", "Macroscopic hematuria", getUnqualifiedIndidualId());
+        PhenotypicFeature pf2 = PhenotypicFeature.createObservation("HP:0011463", "Macroscopic hematuria", getUnqualifiedIndividualId());
         features.add(pf2);
-        PhenotypicFeature pf3 = PhenotypicFeature.createObservation("HP:0001270", "Motor delay", getUnqualifiedIndidualId());
+        PhenotypicFeature pf3 = PhenotypicFeature.createObservation("HP:0001270", "Motor delay", getUnqualifiedIndividualId());
         features.add(pf3);
         return features;
     }
@@ -116,7 +117,7 @@ public class BethlemMyopathyExample implements PhenoExample {
         SimpleQuantity high = new SimpleQuantity();
         low.setValue(100).setSystem("http://unitsofmeasure.org").setCode("mg");
         measurement.getReferenceRangeFirstRep().setHigh(high);
-        measurement.setSubject(new Reference( "Patient/"+getUnqualifiedIndidualId()  ));
+        measurement.setSubject(new Reference( "Patient/"+getUnqualifiedIndividualId()  ));
 
         Reference perf = measurement.addPerformer();
         perf.setDisplay(williamHarvey.getDisplayName()).setReference(williamHarvey.getReference());
@@ -155,7 +156,7 @@ public class BethlemMyopathyExample implements PhenoExample {
         phenopacketsVariant.oneBasedCoordinateSystem();
         phenopacketsVariant.setVariationCode("NM_001848.3:c.877G>A", "NP_001839.2:p.(Gly293Arg)");
         phenopacketsVariant.setStatus(Observation.ObservationStatus.FINAL);
-        phenopacketsVariant.setPatientId(getUnqualifiedIndidualId());
+        phenopacketsVariant.setPatientId(getUnqualifiedIndividualId());
         return phenopacketsVariant;
     }
 
@@ -187,7 +188,7 @@ public class BethlemMyopathyExample implements PhenoExample {
     @Override
     public PhenopacketsGenomicInterpretation addGenomicInterpretation(PhenopacketsVariant variant) {
         PhenopacketsGenomicInterpretation genomicInterpretation = new PhenopacketsGenomicInterpretation();
-        genomicInterpretation.setPatientId(getUnqualifiedIndidualId());
+        genomicInterpretation.setPatientId(getUnqualifiedIndividualId());
         genomicInterpretation.causativeStatus();
         genomicInterpretation.addResult(variant);
         return genomicInterpretation;

--- a/src/main/java/org/monarchinitiative/hapiphenoclient/examples/PhenoExample.java
+++ b/src/main/java/org/monarchinitiative/hapiphenoclient/examples/PhenoExample.java
@@ -22,7 +22,7 @@ public interface PhenoExample {
     void setPhenopacketId(IIdType phenopacketId);
 
     IIdType getPhenopacketId();
-    String getUnqualifiedIndidualId();
+    String getUnqualifiedIndividualId();
     PhenopacketsVariant createPhenopacketsVariant();
     PhenopacketsGenomicInterpretation addGenomicInterpretation(PhenopacketsVariant variant);
 

--- a/src/main/java/org/monarchinitiative/hapiphenoclient/phenopacket/Phenopacket.java
+++ b/src/main/java/org/monarchinitiative/hapiphenoclient/phenopacket/Phenopacket.java
@@ -42,7 +42,7 @@ public class Phenopacket extends Composition {
                 List<Reference> reflist = c.getEntry();
                 for (Reference ref : reflist) {
                     String id = ref.getReference();
-                    // need to get from server
+                    // need to get from server: TODO
                 }
             }
         }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 hapi.server=http://localhost:8888/fhir
 application.version=0.1.1
 application.title=HAPI Pheno Client
+ig.path=/Users/roederc/work/git_phenopackets/core-ig


### PR DESCRIPTION
added call to setIdentifier on the Phenopacket in BethlemMyopathyExample
corrected the spelling of getUnqualifiedIndividual()
left a path to my core-ig in the application.properties
added the mvn commnad to run the Runner in the Readme.md