### PR TITLE
Refactor?

### DIFF
--- a/src/main/java/org/monarchinitiative/hapiphenoclient/PhenoClientConsoleApplication.java
+++ b/src/main/java/org/monarchinitiative/hapiphenoclient/PhenoClientConsoleApplication.java
@@ -40,15 +40,33 @@ public class PhenoClientConsoleApplication implements CommandLineRunner {
     @Override
     public void run(String... args) {
         LOG.info("EXECUTING : command line runner");
+
+        // Create and post Bethlem data to FHIR server
         PhenoExample bethlem = demoRunner.postBethlemClinicalExample();
-        System.out.println("Retrieving phenopacket " + bethlem.getPhenopacketId().getIdPart());
+
+
+        // Retrieve packet from FHIR server
+        System.out.println("\nApp:Retrieving phenopacket " + bethlem.getPhenopacketId().getIdPart());
         Bundle patientBundle = demoRunner.searchForPhenopacketById(bethlem.getPhenopacketId());
         System.out.println(patientBundle);
+
+
+        // extract parts from FHIR Bundle & create Phenopacket
         System.out.println("*************************");
+        System.out.println("\nApp:Fetch Individual from FHIR server"); //, xtract parts and create Phenopacket ");
         Individual individual = demoRunner.extractIndividual(bethlem.getUnqualifiedIndividualId());
+        System.out.println("\nApp:Fetch Features from FHIR server"); //, xtract parts and create Phenopacket ");
         List<PhenotypicFeature> features = demoRunner.retrievePhenotypicFeaturesFromBundle(patientBundle);
+        System.out.println("\nApp:Fetch Measurements from FHIR server"); //, xtract parts and create Phenopacket ");
         List<Measurement> measurements = demoRunner.retrieveMeasurementsFromBundle(patientBundle);
+
+        // TODO: could you have retreived a bundle, or the whole (?) composition from the FHIR server with a single call?
+        // I don't know the structures well enough yet to ask.
+
+        System.out.println("\nCreate phenopacket protobuf");
         Phenopacket ga4ghPhenopacket = Ga4GhPhenopacket.fromFhir(individual, features, measurements);
+
+        System.out.println("\nApp:Show phenopacket contents");
         try {
             String json = JsonFormat.printer().print(ga4ghPhenopacket);
             System.out.println(json);

--- a/src/main/java/org/monarchinitiative/hapiphenoclient/PhenoClientConsoleApplication.java
+++ b/src/main/java/org/monarchinitiative/hapiphenoclient/PhenoClientConsoleApplication.java
@@ -2,14 +2,10 @@ package org.monarchinitiative.hapiphenoclient;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
-import org.hl7.fhir.r4.model.Bundle;
 import org.monarchinitiative.hapiphenoclient.analysis.PhenopacketDemoRunner;
-import org.monarchinitiative.hapiphenoclient.examples.PhenoExample;
+import org.monarchinitiative.hapiphenoclient.analysis.PhenopacketDemoRunner.FhirParts;
 import org.monarchinitiative.hapiphenoclient.ga4gh.Ga4GhPhenopacket;
-import org.monarchinitiative.hapiphenoclient.phenopacket.Individual;
-import org.monarchinitiative.hapiphenoclient.phenopacket.Measurement;
-import org.monarchinitiative.hapiphenoclient.phenopacket.PhenotypicFeature;
-import org.phenopackets.schema.v2.Phenopacket;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,30 +37,9 @@ public class PhenoClientConsoleApplication implements CommandLineRunner {
     public void run(String... args) {
         LOG.info("EXECUTING : command line runner");
 
-        // Create and post Bethlem data to FHIR server
-        PhenoExample bethlem = demoRunner.postBethlemClinicalExample();
-
-
-        // Retrieve packet from FHIR server
-        System.out.println("\nApp:Retrieving phenopacket " + bethlem.getPhenopacketId().getIdPart());
-        Bundle patientBundle = demoRunner.searchForPhenopacketById(bethlem.getPhenopacketId());
-        System.out.println(patientBundle);
-
-
-        // extract parts from FHIR Bundle & create Phenopacket
-        System.out.println("*************************");
-        System.out.println("\nApp:Fetch Individual from FHIR server"); //, xtract parts and create Phenopacket ");
-        Individual individual = demoRunner.extractIndividual(bethlem.getUnqualifiedIndividualId());
-        System.out.println("\nApp:Fetch Features from FHIR server"); //, xtract parts and create Phenopacket ");
-        List<PhenotypicFeature> features = demoRunner.retrievePhenotypicFeaturesFromBundle(patientBundle);
-        System.out.println("\nApp:Fetch Measurements from FHIR server"); //, xtract parts and create Phenopacket ");
-        List<Measurement> measurements = demoRunner.retrieveMeasurementsFromBundle(patientBundle);
-
-        // TODO: could you have retreived a bundle, or the whole (?) composition from the FHIR server with a single call?
-        // I don't know the structures well enough yet to ask.
-
-        System.out.println("\nCreate phenopacket protobuf");
-        Phenopacket ga4ghPhenopacket = Ga4GhPhenopacket.fromFhir(individual, features, measurements);
+        demoRunner.postToFhir();
+        FhirParts fhirParts = demoRunner.retrieveFhirParts();
+        org.phenopackets.schema.v2.Phenopacket ga4ghPhenopacket = demoRunner.assemblePhenopacket(fhirParts);
 
         System.out.println("\nApp:Show phenopacket contents");
         try {

--- a/src/main/java/org/monarchinitiative/hapiphenoclient/analysis/PhenopacketDemoRunner.java
+++ b/src/main/java/org/monarchinitiative/hapiphenoclient/analysis/PhenopacketDemoRunner.java
@@ -2,23 +2,48 @@ package org.monarchinitiative.hapiphenoclient.analysis;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.model.primitive.IdDt;
+
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Composition;
+import org.hl7.fhir.r4.model.DateType;
+import org.hl7.fhir.r4.model.HumanName;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Practitioner;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.instance.model.api.IIdType;
+
 import ca.uhn.fhir.narrative.CustomThymeleafNarrativeGenerator;
 import ca.uhn.fhir.parser.IParser;
 import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.client.interceptor.LoggingInterceptor;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
-import org.hl7.fhir.instance.model.api.IIdType;
-import org.hl7.fhir.r4.model.*;
+
 import org.monarchinitiative.hapiphenoclient.examples.BethlemMyopathyExample;
 import org.monarchinitiative.hapiphenoclient.examples.PhenoExample;
 import org.monarchinitiative.hapiphenoclient.except.PhenoClientRuntimeException;
 import org.monarchinitiative.hapiphenoclient.fhir.util.MyPractitioner;
-import org.monarchinitiative.hapiphenoclient.phenopacket.*;
+import org.monarchinitiative.hapiphenoclient.ga4gh.Ga4GhPhenopacket;
+
+// Both used here, but package is explicitly mentioned to distinguish them
+//import org.monarchinitiative.hapiphenoclient.phenopacket.Phenopacket;
+//import org.phenopackets.schema.v2.Phenopacket;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import org.monarchinitiative.hapiphenoclient.examples.PhenoExample;
+import org.monarchinitiative.hapiphenoclient.phenopacket.Individual;
+import org.monarchinitiative.hapiphenoclient.phenopacket.Measurement;
+import org.monarchinitiative.hapiphenoclient.phenopacket.PhenotypicFeature;
+import org.monarchinitiative.hapiphenoclient.phenopacket.PhenopacketsVariant;
+import org.monarchinitiative.hapiphenoclient.phenopacket.PhenopacketsGenomicInterpretation;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,7 +60,10 @@ public class PhenopacketDemoRunner {
 
     private final FhirContext ctx;
 
+    private PhenoExample bethlem;
+
     private final LoggingInterceptor loggingInterceptor;
+
 
     public PhenopacketDemoRunner() {
         ctx = FhirContext.forR4();
@@ -83,7 +111,7 @@ public class PhenopacketDemoRunner {
     public Bundle searchForPhenopacketById(IIdType id) {
         IGenericClient client = ctx.newRestfulGenericClient(this.hapiUrl);
         Bundle response = client.search()
-                .forResource(Phenopacket.class)
+                .forResource(org.monarchinitiative.hapiphenoclient.phenopacket.Phenopacket.class)
                 .where(Resource.RES_ID.exactly().code(id.getIdPart()))
                 .returnBundle(Bundle.class)
                 .execute();
@@ -244,7 +272,7 @@ public class PhenopacketDemoRunner {
 
 
         System.out.println("\nPUT phenopacket/composition");
-        Phenopacket fhirPhenopacket = bethlem.phenopacket();
+        org.monarchinitiative.hapiphenoclient.phenopacket.Phenopacket fhirPhenopacket = bethlem.phenopacket();
         IGenericClient client = ctx.newRestfulGenericClient(this.hapiUrl);
         MethodOutcome methodOutcome = client.update().resource(fhirPhenopacket).execute();
         if (methodOutcome.getId() == null) {
@@ -262,7 +290,7 @@ public class PhenopacketDemoRunner {
                                                 .setSystem("http://ga4gh.org/fhir/phenopackets/CodeSystem/SectionType")));
         fhirPhenopacket.addSection(phenotypicFeaturesSection);
         int i=1;
-        for (PhenotypicFeature pfeature : phenotypicFeatureList) 
+        for (PhenotypicFeature pfeature : phenotypicFeatureList) {
             System.out.println("\nPOST observation PUT phenopacket/composition features " + i++);
             IIdType pfeatureId = postResource(pfeature);
             pfeature.setId(pfeatureId.getIdPart());
@@ -278,11 +306,12 @@ public class PhenopacketDemoRunner {
                                 .addCoding(new Coding()
                                         .setCode("measurements")
                                         .setSystem("http://ga4gh.org/fhir/phenopackets/CodeSystem/SectionType")));
+
         fhirPhenopacket.addSection(measurementSection);
         List<Measurement> measurementList = bethlem.measurementList();
-        i=1;
+        int j=1;
         for (Measurement measurement : measurementList) {
-            System.out.println("\nPOST measurement PUT phenopacket " + i++);
+            System.out.println("\nPOST measurement PUT phenopacket " + j++);
             IIdType measurementId = postResource(measurement);
             measurement.setId(measurementId.getIdPart());
             measurementSection.addEntry(new Reference(measurement));
@@ -321,5 +350,57 @@ public class PhenopacketDemoRunner {
             throw new PhenoClientRuntimeException("Could not retrieve individual with id "+ individualId);
         }
         return indi;
+    }
+
+    public class FhirParts {
+        // does java14 have some kind of struct/record for this?
+        Bundle bundle; 
+        Individual individual;
+        List<PhenotypicFeature> features; 
+        List<Measurement> measurements; 
+
+        public FhirParts(Bundle bundle,
+                         Individual individual,
+                         List<PhenotypicFeature> features, 
+                         List<Measurement> measurements) {
+            this.bundle = bundle;
+            this.individual = individual;
+            this.features = features;
+            this.measurements = measurements;
+        }
+
+        public Bundle getBundle() { return bundle; }
+        public Individual getIndividual() { return individual; }
+        public List<PhenotypicFeature> getFeatures() { return features; }
+        public List<Measurement> getMeasurements() {return measurements; }
+    }
+    public void postToFhir() {
+        // Create and post Bethlem data to FHIR server
+        bethlem = postBethlemClinicalExample();
+    }
+
+    public FhirParts  retrieveFhirParts() {
+        // Retrieve packet (bundle, this is FHIR)from FHIR server
+        System.out.println("\nApp:Retrieving phenopacket " + bethlem.getPhenopacketId().getIdPart());
+        Bundle patientBundle = searchForPhenopacketById(bethlem.getPhenopacketId());
+        System.out.println(patientBundle);
+
+        System.out.println("*************************");
+        System.out.println("\nApp:Fetch Individual from FHIR server"); //, xtract parts and create Phenopacket ");
+        Individual individual = extractIndividual(bethlem.getUnqualifiedIndividualId());
+        System.out.println("\nApp:Fetch Features from FHIR server"); //, xtract parts and create Phenopacket ");
+        List<PhenotypicFeature> features = retrievePhenotypicFeaturesFromBundle(patientBundle);
+        System.out.println("\nApp:Fetch Measurements from FHIR server"); //, xtract parts and create Phenopacket ");
+        List<Measurement> measurements = retrieveMeasurementsFromBundle(patientBundle);
+
+        return(new FhirParts(patientBundle, individual, features, measurements));
+    }
+
+    public org.phenopackets.schema.v2.Phenopacket assemblePhenopacket(FhirParts fhirParts) {
+        System.out.println("\nCreate phenopacket protobuf");
+        org.phenopackets.schema.v2.Phenopacket ga4ghPhenopacket = Ga4GhPhenopacket.fromFhir(fhirParts.getIndividual(), 
+                                            fhirParts.getFeatures(), fhirParts.getMeasurements() );
+        return ga4ghPhenopacket;
+
     }
 }

--- a/src/main/java/org/monarchinitiative/hapiphenoclient/analysis/PhenopacketDemoRunner.java
+++ b/src/main/java/org/monarchinitiative/hapiphenoclient/analysis/PhenopacketDemoRunner.java
@@ -188,7 +188,7 @@ public class PhenopacketDemoRunner {
     }
 
 
-    private void prelims() {
+    private void postPractitioners() {
         MyPractitioner williamHarvey = MyPractitioner.harvey();
         Practitioner practitioner = new Practitioner();
         practitioner.setId(williamHarvey.getId());
@@ -233,12 +233,17 @@ public class PhenopacketDemoRunner {
 
 
     public PhenoExample postBethlemClinicalExample() {
-        prelims();
+
+        System.out.println("\nPUT practitioners");
+        postPractitioners();
+
+        System.out.println("\nPOST patient");
         BethlemMyopathyExample bethlem = new BethlemMyopathyExample();
         IIdType individualId = postResource(bethlem.individual());
         bethlem.setIndividualId(individualId);
 
 
+        System.out.println("\nPUT phenopacket/composition");
         Phenopacket fhirPhenopacket = bethlem.phenopacket();
         IGenericClient client = ctx.newRestfulGenericClient(this.hapiUrl);
         MethodOutcome methodOutcome = client.update().resource(fhirPhenopacket).execute();
@@ -256,12 +261,16 @@ public class PhenopacketDemoRunner {
                                                 .setCode("phenotypic_features")
                                                 .setSystem("http://ga4gh.org/fhir/phenopackets/CodeSystem/SectionType")));
         fhirPhenopacket.addSection(phenotypicFeaturesSection);
-        for (PhenotypicFeature pfeature : phenotypicFeatureList) {
+        int i=1;
+        for (PhenotypicFeature pfeature : phenotypicFeatureList) 
+            System.out.println("\nPOST observation PUT phenopacket/composition features " + i++);
             IIdType pfeatureId = postResource(pfeature);
             pfeature.setId(pfeatureId.getIdPart());
             phenotypicFeaturesSection.addEntry(new Reference(pfeature));
             client.update().resource(fhirPhenopacket).execute();
         }
+
+
         Composition.SectionComponent measurementSection =
                 new Composition.SectionComponent()
                         .setTitle("measurements")
@@ -271,23 +280,33 @@ public class PhenopacketDemoRunner {
                                         .setSystem("http://ga4gh.org/fhir/phenopackets/CodeSystem/SectionType")));
         fhirPhenopacket.addSection(measurementSection);
         List<Measurement> measurementList = bethlem.measurementList();
+        i=1;
         for (Measurement measurement : measurementList) {
+            System.out.println("\nPOST measurement PUT phenopacket " + i++);
             IIdType measurementId = postResource(measurement);
             measurement.setId(measurementId.getIdPart());
             measurementSection.addEntry(new Reference(measurement));
             client.update().resource(fhirPhenopacket).execute();
         }
+
+
+// TODO
+        System.out.println("\n(TODO) POST variant");
         PhenopacketsVariant variant = bethlem.createPhenopacketsVariant();
         IParser parser = ctx.newJsonParser();
         parser.setPrettyPrint(true);
+
+        System.out.println("\nShow local version of variant");
         System.out.println(parser.encodeResourceToString(variant));
         //IIdType variantId = postResource(variant);
+
+        System.out.println("\nShow local version of report on variant");
         PhenopacketsGenomicInterpretation genomicInterpretation = bethlem.addGenomicInterpretation(variant);
         System.out.println(parser.encodeResourceToString(genomicInterpretation));
         return bethlem;
     }
 
-
+// TODO: fetch patients from FHIR and show? ...using extractIndividual function below?
     /*
     List<Bundle.BundleEntryComponent> entries = patientBundle.getEntry();
         for (var entry : entries) {

--- a/src/main/java/org/monarchinitiative/hapiphenoclient/examples/BethlemMyopathyExample.java
+++ b/src/main/java/org/monarchinitiative/hapiphenoclient/examples/BethlemMyopathyExample.java
@@ -4,6 +4,7 @@ import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.*;
 import org.monarchinitiative.hapiphenoclient.fhir.util.MyPractitioner;
 import org.monarchinitiative.hapiphenoclient.phenopacket.*;
+import org.monarchinitiative.hapiphenoclient.phenopacket.Phenopacket; // not a org.phenopackets.schema.v2.Phenopacket!!!!
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;


### PR DESCRIPTION
This is mostly a readability PR consisting of changes I made while learning the code.
- expand wildcarded imports
- rename prelims() postPractioners()
- has the LOINC path fixes from a different PR
- The meat of the PR is be able write lines 40-42 of the PhenoClientConsoleApplication revision.
  - add an inner class to the Runner, FhirParts, that is a bean or struct of the parts that go into a phenopacket
  - use FhirParts to show the interaction between postToFhir and assemblePhenopackets a little more abstractly

it's incomplete. 
- Separating the creation of the Bethlem example parts from posting them, might be a refinement.
- I might refine the names of things: bundle in the fhir-world, but phenopacket when it's a Ga4GhPhenopacket. I definitely got tripped up on org.monarchinitiative.hapiphenoclient.phenopacket.Phenopacket vs org.phenopackets.schema.v2.Phenopacket. Look at lines 275 and 401 in the Runner where I name the classes explicitly.